### PR TITLE
Increase title

### DIFF
--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -47,6 +47,7 @@ main {
     position: relative;
     .post-header {
         text-align: center;
+        font-size: xx-large;
         margin-bottom: 0;
     }
     .post-meta {


### PR DESCRIPTION
Increases the source of posts and page titles, they were smaller than one "h2" title (##).

Example:
![screenshot_2018-06-29 joao thallis](https://user-images.githubusercontent.com/25409344/42120724-89e27008-7bf6-11e8-8a43-0a7efe41b5a2.png)
